### PR TITLE
bugfix: allow empty lines in the Stockholm file

### DIFF
--- a/src/align.c
+++ b/src/align.c
@@ -247,6 +247,8 @@ struct Alignment *read_Stockholm_Alignment( FILE *handle ) {
       
       if (line[0] == comment)
 	continue;
+      if (line[0] == '\n')
+	continue;
       else if (strncmp(line, terminator, 2) == 0) {
 	break;
       }


### PR DESCRIPTION
The file I'm trying to parse has blank lines here:
```
# STOCKHOLM 1.0

#=GF ID 3434
#=GS 800301218              AC unknown
#=GS 800975376              AC unknown
```
and there
```
#=GS 100080538              AC unknown
#=GS 801021330              AC unknown

800301218  -------------------TCTCAGGC-TGTGACCGTCTCGAGGAAA---GAAGCACTTTCTGTT----GTCTT--A-AAGCAA--A-G-AAAGTGTTTC-TTT--CCCGAGG-GTT-A-CGGTT-TG-AG-A-------------------
800975376  -------------AGAAGATCTCATGC-TGTGACTCTC---TGGAGG---GAAGCACTTTCTGTT----GTCTG--A-AAGAAA--A-C-AAAGCGCTTC-TCT--TTAGAGT-GTT-A-CGGTT-TG-AG-AAAAGC--------------
```

Without the patch, quicktree fails with the error "The alignment file is not valid Stockholm format"