### PR TITLE
Fix of memory access violation bug and reparenting bug

### DIFF
--- a/src/distancemat.c
+++ b/src/distancemat.c
@@ -259,7 +259,7 @@ struct DistanceMatrix *empty_DistanceMatrix( unsigned int size) {
 
   for( i=0; i < mat->size; i++) {
     mat->data[i] = (Distance *) malloc_util( (i+1) * sizeof(Distance) );
-    for( j=0; j < i; j++) 
+    for( j=0; j <= i; j++) 
       mat->data[i][j] = 0.0;
   }
  

--- a/src/tree.c
+++ b/src/tree.c
@@ -306,7 +306,7 @@ struct Tree *get_root_Tnode( struct Tree *source ) {
 
   focal->left = children[focalleft];
   focal->right = children[focalright];
-  children[focalleft]->parent = children[focalright] = focal;
+  children[focalleft]->parent = children[focalright]->parent = focal;
 
   ret = empty_Tree();
   ret->child[0] = root;


### PR DESCRIPTION
- Diagonal of distance matrix is now initialized to 0, in case of direct indexing (cause of access violation bug currently)
- The parent of the right focal subtree is now set correctly to the same parent as the left focal subtree